### PR TITLE
Unrotate bionic fbconsole, as this makes no sense on bionic and break…

### DIFF
--- a/rootfs-overlay/bionic/boot/boot/boot.cfg
+++ b/rootfs-overlay/bionic/boot/boot/boot.cfg
@@ -2,12 +2,12 @@ LABEL=Maemo Leste
 PRIORITY=8
 DTB=/boot/omap4-droid-bionic-xt875.dtb
 KERNEL=/boot/zImage
-CMDLINE=console=tty0 console=ttyS2,115200 fbcon=rotate:1 debug earlycon ro rootwait rootfstype=ext4 root=/dev/mmcblk0p2
+CMDLINE=console=tty0 console=ttyS2,115200 debug earlycon ro rootwait rootfstype=ext4 root=/dev/mmcblk0p2
 TIMEOUT=5
 
 LABEL=Maemo Leste Emergency Shell
 PRIORITY=7
 DTB=/boot/omap4-droid-bionic-xt875.dtb
 KERNEL=/boot/zImage
-CMDLINE=console=tty0 console=ttyS2,115200 fbcon=rotate:1 debug earlycon ro rootwait rootfstype=ext4 root=/dev/mmcblk0p2 softlevel=recovery
+CMDLINE=console=tty0 console=ttyS2,115200 debug earlycon ro rootwait rootfstype=ext4 root=/dev/mmcblk0p2 softlevel=shell
 TIMEOUT=5


### PR DESCRIPTION
…s fbkeyboard

boot to fbkeyboard shell in emergency mode as normal single user mode is not usable on bionic